### PR TITLE
fix: make property `Item.id` required

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2150,7 +2150,7 @@ Detailed information about order (type `GOODS` and `GOODS_BROKER`)
 Order item information, needed to create an application.
 
 ### Properties
-+ `id`: `item-id-string` (string, optional, nullable) - Item Id
++ `id`: `item-id-string` (string, required) - Item Id
 + `name`: `iPhone 6s 32GB SpaceGray` (string, required) - Item name
 + `totalPrice` (Amount, required) - Total price for all pieces, VAT inclusive (if applicable)
 + `image` (File, optional) - Item image


### PR DESCRIPTION
Na FE potřebujeme mít ID vždy k dispozici a musí být unikátní. Impelmentace dle vyjádření @matllubos toto splňuje, zbývá upravit schema.