### PR TITLE
refactor: use `isPurchased` flag instead `type` enum

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2685,10 +2685,7 @@ Reward description
 + `type` (enum, required) - type of reward
     + `FREE_DELIVERY`
     + `SERVICE_DISCOUNT`
-+ `status` (enum, required) - status of the reward
-    + `PURCHASED` - reward was purchased
-    + `AVAILABLE` - reward is available for purchase
-    + `NOT_ENOUGH_COINS` - customer does not have enough coins to purchase the reward
++ `isPurchased` (boolean, required) - flag for already purchased rewards
 + `relatedObjects` (enum)
     + serviceId (string, optional, nullable)
 


### PR DESCRIPTION
To jestli má uživatel dostatek MC na pořízení Reward se musí na FE přepočítávat jak uživatel výhody zaklikává. Proto je state `NOT_ENOUGH_COINS ` zbytečný. Ze dvou  zbývajících stavů `AVAILABLE` a `PURCHASED` jsme udělali příznak `isPurchased`. Implementuje Zuzka. 